### PR TITLE
Ps whiskey search

### DIFF
--- a/api/whiskey.json
+++ b/api/whiskey.json
@@ -1389,6 +1389,1316 @@
         ],
         "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683156/bvsvfyaj2ul25ovystrl.jpg",
         "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689233/nt1zievcfzhidflqe0iz.jpg"
+    },
+    {
+        "id": 69,
+        "title": "Auchentoshan American Oak",
+        "img_url": "http://www.auchentoshan.com/media/39080/central-hero-images-core-range-ao.png",
+        "region": "Other",
+        "price": 26,
+        "rating": 72,
+        "description": "This is an excellent whiskey with notes of fruit and a strong finish. Accesible, but also complex enough for a seasoned drinker.",
+        "reviews": [],
+        "comparables": [
+            {
+                "id": 212,
+                "title": "Forty Creek Confederation Oak",
+                "img_url": "https://legacyliquorstore.com/sites/default/files/styles/product_image_large/public/471235.png",
+                "rating": 82,
+                "price": 23,
+                "region": "Other",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463682947/xb8xo007cy3yg8cflhki.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463688987/lqwghure8ggw824bw52j.jpg"
+            },
+            {
+                "id": 258,
+                "title": "Glenfiddich 15 Distillery Edition",
+                "img_url": "http://www.glengarrywines.co.nz/images/v9/bottles/93509.png",
+                "rating": 81,
+                "price": 60,
+                "region": "Speyside",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463682969/q0yamugc5hzxiqkqmbxs.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689014/uylqzrdreirhzzxgsz9k.jpg"
+            },
+            {
+                "id": 191,
+                "title": "Deanston Virgin Oak",
+                "img_url": "http://beowein.eshop.t-online.de/WebRoot/Store8/Shops/Shop538/5306/70E4/7411/00CC/96CA/AC14/504B/2F54/42865_deanston_virgin_oak_fl.png",
+                "rating": 74,
+                "price": 18,
+                "region": "Highland",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463682935/md5z1zgrivalnrka0cbn.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463688973/t3m5j4ehwoj2dwkipjyz.jpg"
+            }
+        ],
+        "comparable": [
+            134,
+            212,
+            430,
+            448
+        ],
+        "tags": [
+            {
+                "title": "oak",
+                "count": 4,
+                "normalized_count": 66
+            },
+            {
+                "title": "vanilla",
+                "count": 2,
+                "normalized_count": 33
+            },
+            {
+                "title": "candy",
+                "count": 1,
+                "normalized_count": 16
+            },
+            {
+                "title": "balanced",
+                "count": 2,
+                "normalized_count": 33
+            },
+            {
+                "title": "lemon",
+                "count": 1,
+                "normalized_count": 16
+            },
+            {
+                "title": "dry",
+                "count": 2,
+                "normalized_count": 33
+            }
+        ],
+        "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683159/xts833ubfemccvpmitgv.jpg",
+        "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689236/he5jtimrq2xysigikmiq.jpg"
+    },
+    {
+        "id": 71,
+        "title": "Auchentoshan Three Wood",
+        "img_url": "http://www.auchentoshan.com/media/8788/central-hero-images-core-range-3wood.png",
+        "region": "Other",
+        "price": 59,
+        "rating": 82,
+        "description": "This is an excellent whiskey with notes of fruit and a strong finish. Accesible, but also complex enough for a seasoned drinker.",
+        "reviews": [],
+        "comparables": [
+            {
+                "id": 59,
+                "title": "Ardbeg Uigeadail",
+                "img_url": "https://www.glengarrywines.co.nz/images/v9/bottles/93270.png",
+                "rating": 92,
+                "price": 63,
+                "region": "Islay",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683151/kuztenryd9ar0pymjb0l.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689227/dn6m3yfj36jqr4dfig4m.jpg"
+            },
+            {
+                "id": 151,
+                "title": "Bunnahabhain 12",
+                "img_url": "http://whiskyjerk.com/wp-content/uploads/2013/03/bunnahabhain12yr.png",
+                "rating": 86,
+                "price": 48,
+                "region": "Islay",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463682906/agohnwp5gxq18kyqpazf.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463688941/hnrzq85gyyccqcbfh4me.jpg"
+            },
+            {
+                "id": 355,
+                "title": "Lagavulin 16",
+                "img_url": "https://flaviar.com/gui/img/2014/11/10/18/2014111018_lagavulin16_web_original.png",
+                "rating": 88,
+                "price": 70,
+                "region": "Islay",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683036/timnwb5uiw0oo0twd2sx.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689089/wpmxs2ljvxi94mjt5vvo.jpg"
+            }
+        ],
+        "comparable": [
+            24,
+            152,
+            241,
+            366,
+            372,
+            460
+        ],
+        "tags": [
+            {
+                "title": "brown",
+                "count": 2,
+                "normalized_count": 4
+            },
+            {
+                "title": "sweet",
+                "count": 3,
+                "normalized_count": 6
+            },
+            {
+                "title": "sherry",
+                "count": 4,
+                "normalized_count": 9
+            },
+            {
+                "title": "wood",
+                "count": 4,
+                "normalized_count": 9
+            },
+            {
+                "title": "sugar",
+                "count": 2,
+                "normalized_count": 4
+            },
+            {
+                "title": "fruity",
+                "count": 2,
+                "normalized_count": 4
+            },
+            {
+                "title": "smokey",
+                "count": 2,
+                "normalized_count": 4
+            },
+            {
+                "title": "smooth",
+                "count": 2,
+                "normalized_count": 4
+            }
+        ],
+        "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683160/mc6uec4shodrelj6bf6d.jpg",
+        "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689237/yr54smdcjtwxymmcb8ot.jpg"
+    },
+    {
+        "id": 76,
+        "title": "Balcones Texas Single Malt",
+        "img_url": "http://www.balconesdistilling.com/images/bottles/single-malt-2015.png",
+        "region": "American",
+        "price": 60,
+        "rating": 85,
+        "description": "This is an excellent whiskey with notes of fruit and a strong finish. Accesible, but also complex enough for a seasoned drinker.",
+        "reviews": [],
+        "comparables": [
+            {
+                "id": 316,
+                "title": "Jack Daniel's Single Barrel",
+                "img_url": "http://static1.businessinsider.com/image/5487179b69beddce227f2faf-480/single-barrel-jack-daniels.png",
+                "rating": 76,
+                "price": 36,
+                "region": "American",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683011/mxslvon38ir8zyhx9m3q.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689060/nyoun7dqtaa6tycl4eln.jpg"
+            },
+            {
+                "id": 261,
+                "title": "Glenfiddich Snow Phoenix",
+                "img_url": "http://www.pijewhisky.pl/_images_content/whisky/150x300/144113869178.png",
+                "rating": 86,
+                "price": 116,
+                "region": "Speyside",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463682973/pdutjwxymclaezs2h9lw.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689018/mcvlau8qktakkzrcocpz.jpg"
+            },
+            {
+                "id": 22,
+                "title": "Aberlour 12 Non Chill Filtered",
+                "img_url": "http://www.bevindustry.com/ext/resources/archives/a/Aberlour-Feature.jpg?1328846050",
+                "rating": 89,
+                "price": 54,
+                "region": "Speyside",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683066/axsfxttzigvbf1bfvki8.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689119/b9c19mrjwesamr1vxtt8.jpg"
+            }
+        ],
+        "comparable": [
+            113,
+            321
+        ],
+        "tags": [
+            {
+                "title": "caramel",
+                "count": 2,
+                "normalized_count": 25
+            },
+            {
+                "title": "amber",
+                "count": 1,
+                "normalized_count": 12
+            },
+            {
+                "title": "sour",
+                "count": 2,
+                "normalized_count": 25
+            },
+            {
+                "title": "salty",
+                "count": 2,
+                "normalized_count": 25
+            },
+            {
+                "title": "rich",
+                "count": 4,
+                "normalized_count": 50
+            },
+            {
+                "title": "oak",
+                "count": 4,
+                "normalized_count": 50
+            },
+            {
+                "title": "wood",
+                "count": 4,
+                "normalized_count": 50
+            },
+            {
+                "title": "vanilla",
+                "count": 3,
+                "normalized_count": 37
+            },
+            {
+                "title": "sugar",
+                "count": 3,
+                "normalized_count": 37
+            },
+            {
+                "title": "honey",
+                "count": 1,
+                "normalized_count": 12
+            },
+            {
+                "title": "corn",
+                "count": 6,
+                "normalized_count": 75
+            },
+            {
+                "title": "cocoa",
+                "count": 1,
+                "normalized_count": 12
+            },
+            {
+                "title": "mellow",
+                "count": 2,
+                "normalized_count": 25
+            },
+            {
+                "title": "sweet",
+                "count": 18,
+                "normalized_count": 225
+            },
+            {
+                "title": "creamy",
+                "count": 4,
+                "normalized_count": 50
+            },
+            {
+                "title": "malty",
+                "count": 1,
+                "normalized_count": 12
+            },
+            {
+                "title": "cinnamon",
+                "count": 1,
+                "normalized_count": 12
+            },
+            {
+                "title": "lingering",
+                "count": 2,
+                "normalized_count": 25
+            },
+            {
+                "title": "light",
+                "count": 4,
+                "normalized_count": 50
+            },
+            {
+                "title": "balanced",
+                "count": 2,
+                "normalized_count": 25
+            },
+            {
+                "title": "citrus",
+                "count": 2,
+                "normalized_count": 25
+            }
+        ],
+        "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683163/cpvqmoualcxc8dnmen4g.jpg",
+        "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689241/zszaniqtnryx6ie7fqvd.jpg"
+    },
+    {
+        "id": 18,
+        "title": "1792 Ridgemont Reserve",
+        "img_url": "http://bottlenose.imgix.net/images/full/12051.jpg",
+        "region": "Bourbon",
+        "price": 22,
+        "rating": 82,
+        "description": "This is an excellent whiskey with notes of fruit and a strong finish. Accesible, but also complex enough for a seasoned drinker.",
+        "reviews": [],
+        "comparables": [
+            {
+                "id": 422,
+                "title": "Old Rip Van Winkle 10 Year",
+                "img_url": "http://www.buffalotracedistillery.com/sites/default/files/oldrip.png",
+                "rating": 90,
+                "price": 51,
+                "region": "Bourbon",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683086/cqybpa62oqqqjltkfkue.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689153/trthdfbxedhfxoowkkfy.jpg"
+            },
+            {
+                "id": 204,
+                "title": "Evan Williams Black Label",
+                "img_url": "http://www.stilstoimport.com/wp-content/uploads/2015/08/evan-williams-200x580.png",
+                "rating": 80,
+                "price": 12,
+                "region": "Bourbon",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463682943/duxh0fyh3mxcksw511b2.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463688982/kjyhpxmrwxtv9mlheejy.jpg"
+            },
+            {
+                "id": 464,
+                "title": "Stagg Jr",
+                "img_url": "http://www.buffalotracedistillery.com/sites/default/files/STAGGjr_0.png",
+                "rating": 87,
+                "price": 46,
+                "region": "Bourbon",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683116/kn8cnvspix6rbmcxpsj6.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689189/edwkvdhkz7wiw6zoitws.jpg"
+            }
+        ],
+        "comparable": [
+            83,
+            426,
+            450
+        ],
+        "tags": [
+            {
+                "title": "green",
+                "count": 2,
+                "normalized_count": 18
+            },
+            {
+                "title": "brown",
+                "count": 2,
+                "normalized_count": 18
+            },
+            {
+                "title": "maple",
+                "count": 2,
+                "normalized_count": 18
+            },
+            {
+                "title": "bitter",
+                "count": 4,
+                "normalized_count": 36
+            },
+            {
+                "title": "wood",
+                "count": 2,
+                "normalized_count": 18
+            },
+            {
+                "title": "cinnamon",
+                "count": 2,
+                "normalized_count": 18
+            },
+            {
+                "title": "old",
+                "count": 1,
+                "normalized_count": 9
+            },
+            {
+                "title": "heavy",
+                "count": 2,
+                "normalized_count": 18
+            },
+            {
+                "title": "zest",
+                "count": 1,
+                "normalized_count": 9
+            },
+            {
+                "title": "caramel",
+                "count": 3,
+                "normalized_count": 27
+            },
+            {
+                "title": "oak",
+                "count": 4,
+                "normalized_count": 36
+            },
+            {
+                "title": "sugar",
+                "count": 1,
+                "normalized_count": 9
+            },
+            {
+                "title": "orange",
+                "count": 2,
+                "normalized_count": 18
+            }
+        ],
+        "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683066/axsfxttzigvbf1bfvki8.jpg",
+        "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689119/b9c19mrjwesamr1vxtt8.jpg"
+    },
+    {
+        "id": 56,
+        "title": "Ardbeg Day",
+        "img_url": "http://leece.de/whisky/whiskys/ardbeg-day.gif",
+        "region": "Islay",
+        "price": 242,
+        "rating": 90,
+        "description": "This is an excellent whiskey with notes of fruit and a strong finish. Accesible, but also complex enough for a seasoned drinker.",
+        "reviews": [],
+        "comparables": [
+            {
+                "id": 390,
+                "title": "Macallan Rare Cask",
+                "img_url": "https://media2.caskers.com/media/catalog/product/cache/1/thumbnail/488x/9df78eab33525d08d6e5fb8d27136e95/m/a/macallan-rare-cask-single-malt-scotch-whisky-1.jpg",
+                "rating": 71,
+                "price": 265,
+                "region": "Speyside",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683066/axsfxttzigvbf1bfvki8.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689119/b9c19mrjwesamr1vxtt8.jpg"
+            },
+            {
+                "id": 84,
+                "title": "Balvenie 15 Single Barrel",
+                "img_url": "http://www.thewinestop.com/media/catalog/product/cache/3/image/100x242/9df78eab33525d08d6e5fb8d27136e95/b/a/balvenie_scotch_15_year_single_barrel.png",
+                "rating": 88,
+                "price": 80,
+                "region": "Speyside",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683066/axsfxttzigvbf1bfvki8.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689119/b9c19mrjwesamr1vxtt8.jpg"
+            },
+            {
+                "id": 26,
+                "title": "Aberlour A'bunadh",
+                "img_url": "http://oc.scotchclub.us/wp-content/uploads/Aberlour-Abunadh.png",
+                "rating": 90,
+                "price": 60,
+                "region": "Speyside",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463682971/tdhog6g0lnyanmfmgluw.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689017/davrabmfncsnjpfupxbf.jpg"
+            }
+        ],
+        "comparable": [
+            102,
+            114,
+            378
+        ],
+        "tags": [
+            {
+                "title": "sweet",
+                "count": 4,
+                "normalized_count": 40
+            },
+            {
+                "title": "salty",
+                "count": 2,
+                "normalized_count": 20
+            },
+            {
+                "title": "brine",
+                "count": 1,
+                "normalized_count": 10
+            },
+            {
+                "title": "sherry",
+                "count": 8,
+                "normalized_count": 80
+            },
+            {
+                "title": "wood",
+                "count": 4,
+                "normalized_count": 40
+            },
+            {
+                "title": "vanilla",
+                "count": 6,
+                "normalized_count": 60
+            },
+            {
+                "title": "peaty",
+                "count": 2,
+                "normalized_count": 20
+            },
+            {
+                "title": "honey",
+                "count": 2,
+                "normalized_count": 20
+            },
+            {
+                "title": "orange",
+                "count": 10,
+                "normalized_count": 100
+            },
+            {
+                "title": "lemon",
+                "count": 4,
+                "normalized_count": 40
+            },
+            {
+                "title": "fruity",
+                "count": 2,
+                "normalized_count": 20
+            },
+            {
+                "title": "citrus",
+                "count": 1,
+                "normalized_count": 10
+            }
+        ],
+        "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683066/axsfxttzigvbf1bfvki8.jpg",
+        "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689119/b9c19mrjwesamr1vxtt8.jpg"
+    },
+    {
+        "id": 19,
+        "title": "Aberfeldy 12",
+        "img_url": "https://img.thewhiskyexchange.com/900/abfob.12yov1.jpg",
+        "region": "Highland",
+        "price": 40,
+        "rating": 77,
+        "description": "This is an excellent whiskey with notes of fruit and a strong finish. Accesible, but also complex enough for a seasoned drinker.",
+        "reviews": [],
+        "comparables": [
+            {
+                "id": 498,
+                "title": "W.L. Weller 12",
+                "img_url": "https://media2.caskers.com/media/catalog/product/cache/1/image/1000x/8098fa9a8bdf2c28760c2d2c80a1898c/1/2/1212.png",
+                "rating": 88,
+                "price": 26,
+                "region": "Bourbon",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683141/agshxbn3brwpoulluoqp.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689216/krgj1uvyx0vmcigglare.jpg"
+            },
+            {
+                "id": 21,
+                "title": "Aberlour 12 Double Cask Matured",
+                "img_url": "http://spiritedgifts.com/media/catalog/product/cache/1/small_image/600x600/9df78eab33525d08d6e5fb8d27136e95/_/0/_0019_aberlour-12.png",
+                "rating": 83,
+                "price": 35,
+                "region": "Speyside",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463682946/d4iycov13gwduuwug0pp.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463688985/qc7uyhwjfhak15qmehtu.jpg"
+            },
+            {
+                "id": 143,
+                "title": "Bruichladdich The Laddie Ten",
+                "img_url": "http://www.morze-wina.pl/images/products/zoom/whisky-bowmore-12-yo-713-morze-wina-twoj-sklep-z-winami-wino-1.png",
+                "rating": 86,
+                "price": 50,
+                "region": "Islay",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683066/axsfxttzigvbf1bfvki8.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689119/b9c19mrjwesamr1vxtt8.jpg"
+            }
+        ],
+        "comparable": [
+            64,
+            155,
+            158
+        ],
+        "tags": [
+            {
+                "title": "green",
+                "count": 2,
+                "normalized_count": 8
+            },
+            {
+                "title": "sweet",
+                "count": 6,
+                "normalized_count": 25
+            },
+            {
+                "title": "rich",
+                "count": 3,
+                "normalized_count": 12
+            },
+            {
+                "title": "sherry",
+                "count": 2,
+                "normalized_count": 8
+            },
+            {
+                "title": "wood",
+                "count": 2,
+                "normalized_count": 8
+            },
+            {
+                "title": "vanilla",
+                "count": 4,
+                "normalized_count": 16
+            },
+            {
+                "title": "toffee",
+                "count": 2,
+                "normalized_count": 8
+            },
+            {
+                "title": "honey",
+                "count": 3,
+                "normalized_count": 12
+            },
+            {
+                "title": "chocolate",
+                "count": 5,
+                "normalized_count": 20
+            },
+            {
+                "title": "complex",
+                "count": 1,
+                "normalized_count": 4
+            },
+            {
+                "title": "lemon",
+                "count": 7,
+                "normalized_count": 29
+            },
+            {
+                "title": "fruity",
+                "count": 2,
+                "normalized_count": 8
+            },
+            {
+                "title": "cherry",
+                "count": 5,
+                "normalized_count": 20
+            },
+            {
+                "title": "oak",
+                "count": 7,
+                "normalized_count": 29
+            },
+            {
+                "title": "floral",
+                "count": 1,
+                "normalized_count": 4
+            },
+            {
+                "title": "pear",
+                "count": 1,
+                "normalized_count": 4
+            },
+            {
+                "title": "apple",
+                "count": 1,
+                "normalized_count": 4
+            }
+        ],
+        "list_img_url": "http://res.cloudinary.com/dt4sawqjx/image/upload/v1463683066/axsfxttzigvbf1bfvki8.jpg",
+        "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689119/b9c19mrjwesamr1vxtt8.jpg"
+    },
+    {
+        "id": 20,
+        "title": "Aberlour 10",
+        "img_url": "https://img.thewhiskyexchange.com/900/ablob.10yo.jpg",
+        "region": "Speyside",
+        "price": 23,
+        "rating": 78,
+        "description": "This is an excellent whiskey with notes of fruit and a strong finish. Accesible, but also complex enough for a seasoned drinker.",
+        "reviews": [],
+        "comparables": [
+            {
+                "id": 362,
+                "title": "Laphroaig 18",
+                "img_url": "https://flaviar.com/gui/img/2015/08/27/10/2015082710_laphroaig_18_year_old_original.png",
+                "rating": 89,
+                "price": 77,
+                "region": "Islay",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683040/p3y6pyybuec3dg5nd1cn.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689094/wtoriffnxe7nc4tzt7do.jpg"
+            },
+            {
+                "id": 165,
+                "title": "Cardhu 12",
+                "img_url": "http://bestbuyliquors.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/c/a/cardhu-12-year-old.png",
+                "rating": 76,
+                "price": 32,
+                "region": "Speyside",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463682917/kkyemizxkivzkj6cxvrb.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463688953/qiwtr6kwho6wnpr3ub7k.jpg"
+            },
+            {
+                "id": 147,
+                "title": "Buffalo Trace",
+                "img_url": "http://www.buffalotrace.com/images/img-bottle.png",
+                "rating": 84,
+                "price": 22,
+                "region": "Bourbon",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463682903/dcexwatoej5vwzdex9gb.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463688936/g5fpisj8pgxt02kxztmf.jpg"
+            }
+        ],
+        "comparable": [
+            54,
+            63,
+            66,
+            252,
+            274,
+            359,
+            414,
+            485,
+            510
+        ],
+        "tags": [
+            {
+                "title": "caramel",
+                "count": 1,
+                "normalized_count": 4
+            },
+            {
+                "title": "sweet",
+                "count": 3,
+                "normalized_count": 12
+            },
+            {
+                "title": "rich",
+                "count": 2,
+                "normalized_count": 8
+            },
+            {
+                "title": "vanilla",
+                "count": 5,
+                "normalized_count": 20
+            },
+            {
+                "title": "floral",
+                "count": 1,
+                "normalized_count": 4
+            },
+            {
+                "title": "chocolate",
+                "count": 1,
+                "normalized_count": 4
+            },
+            {
+                "title": "old",
+                "count": 2,
+                "normalized_count": 8
+            },
+            {
+                "title": "balanced",
+                "count": 1,
+                "normalized_count": 4
+            },
+            {
+                "title": "sherry",
+                "count": 2,
+                "normalized_count": 8
+            },
+            {
+                "title": "light",
+                "count": 2,
+                "normalized_count": 8
+            }
+        ],
+        "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683066/axsfxttzigvbf1bfvki8.jpg",
+        "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689119/b9c19mrjwesamr1vxtt8.jpg"
+    },
+    {
+        "id": 106,
+        "title": "Benromach 10 100 Proof",
+        "img_url": "https://whiskycabinet.files.wordpress.com/2015/01/benromach-10_100_proof.png",
+        "region": "Speyside",
+        "price": 69,
+        "rating": 90,
+        "description": "This is an excellent whiskey with notes of fruit and a strong finish. Accesible, but also complex enough for a seasoned drinker.",
+        "reviews": [],
+        "comparables": [
+            {
+                "id": 345,
+                "title": "Kilchoman Loch Gorm",
+                "img_url": "https://www.whiskyandmore.co.nz/uploaded_images/products/kilchoman-loch-gorm-440195-l.png",
+                "rating": 87,
+                "price": 77,
+                "region": "Islay",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683031/ap46wislntc3sxfmnlnm.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689083/nebuwpe86skp6nc4aoi3.jpg"
+            },
+            {
+                "id": 174,
+                "title": "Compass Box Great King St. Artist's Blend",
+                "img_url": "https://media2.caskers.com/media/catalog/product/cache/1/thumbnail/1000x/9df78eab33525d08d6e5fb8d27136e95/g/k/gk2_2.png",
+                "rating": 80,
+                "price": 31,
+                "region": "Other",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463682925/loegxoq4lacbk8btgkon.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463688963/lmfbr3jtz7hnilyni6pf.jpg"
+            },
+            {
+                "id": 252,
+                "title": "Glenfarclas 25",
+                "img_url": "http://diwisa.ch/typo3temp/_processed_/csm_P_Glenfarclas_25j_tin_70cl_res_w120_02_a54404920d.png",
+                "rating": 89,
+                "price": 126,
+                "region": "Speyside",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463682965/rsrildztxldpkphi3wfc.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689010/nfyxpjcji3vvfrcloeji.jpg"
+            }
+        ],
+        "comparable": [
+            26,
+            344,
+            383,
+            472,
+            487
+        ],
+        "tags": [
+            {
+                "title": "caramel",
+                "count": 1,
+                "normalized_count": 12
+            },
+            {
+                "title": "oak",
+                "count": 4,
+                "normalized_count": 50
+            },
+            {
+                "title": "vanilla",
+                "count": 4,
+                "normalized_count": 50
+            },
+            {
+                "title": "old",
+                "count": 2,
+                "normalized_count": 25
+            },
+            {
+                "title": "sherry",
+                "count": 4,
+                "normalized_count": 50
+            },
+            {
+                "title": "raisins",
+                "count": 1,
+                "normalized_count": 12
+            }
+        ],
+        "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463682874/c3dgddkxuno6tpuvqj37.jpg",
+        "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463688899/xdpe1zbnsuvqa48dbvux.jpg"
+    },
+    {
+        "id": 107,
+        "title": "Benromach Traditional",
+        "img_url": "http://shop.whiskybase.com/images/whiskies/51823.png",
+        "region": "Speyside",
+        "price": 36,
+        "rating": 79,
+        "description": "This is an excellent whiskey with notes of fruit and a strong finish. Accesible, but also complex enough for a seasoned drinker.",
+        "reviews": [],
+        "comparables": [
+            {
+                "id": 357,
+                "title": "Lagavulin 1997 Distillers Edition",
+                "img_url": "http://www.liquorandliqueur.com/assets/components/phpthumbof/cache/a3ac02c88596954508fd26e91d374dfb.44a48695f020a1a5189379a0a16a5a9b.png",
+                "rating": 90,
+                "price": 114,
+                "region": "Islay",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683037/j1g4vhatxpcquvnlazdk.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689090/w9z09oirahbv3wxpnsxy.jpg"
+            },
+            {
+                "id": 85,
+                "title": "Balvenie 15 Single Barrel Sherry Cask",
+                "img_url": "https://www.boozebud.com.au/resources/img/product/Balvenie-15yoSherryCask-350-937.gif",
+                "rating": 88,
+                "price": 40,
+                "region": "Speyside",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683066/axsfxttzigvbf1bfvki8.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689119/b9c19mrjwesamr1vxtt8.jpg"
+            },
+            {
+                "id": 261,
+                "title": "Glenfiddich Snow Phoenix",
+                "img_url": "http://www.pijewhisky.pl/_images_content/whisky/150x300/144113869178.png",
+                "rating": 86,
+                "price": 116,
+                "region": "Speyside",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463682973/pdutjwxymclaezs2h9lw.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689018/mcvlau8qktakkzrcocpz.jpg"
+            }
+        ],
+        "comparable": [
+            85
+        ],
+        "tags": [
+            {
+                "title": "brown",
+                "count": 2,
+                "normalized_count": 33
+            },
+            {
+                "title": "smokey",
+                "count": 1,
+                "normalized_count": 16
+            },
+            {
+                "title": "sherry",
+                "count": 6,
+                "normalized_count": 100
+            },
+            {
+                "title": "vanilla",
+                "count": 2,
+                "normalized_count": 33
+            },
+            {
+                "title": "peaty",
+                "count": 2,
+                "normalized_count": 33
+            },
+            {
+                "title": "floral",
+                "count": 4,
+                "normalized_count": 66
+            },
+            {
+                "title": "toffee",
+                "count": 1,
+                "normalized_count": 16
+            },
+            {
+                "title": "honey",
+                "count": 1,
+                "normalized_count": 16
+            },
+            {
+                "title": "mellow",
+                "count": 2,
+                "normalized_count": 33
+            },
+            {
+                "title": "lingering",
+                "count": 1,
+                "normalized_count": 16
+            },
+            {
+                "title": "light",
+                "count": 2,
+                "normalized_count": 33
+            },
+            {
+                "title": "raisins",
+                "count": 1,
+                "normalized_count": 16
+            },
+            {
+                "title": "fruity",
+                "count": 2,
+                "normalized_count": 33
+            },
+            {
+                "title": "citrus",
+                "count": 1,
+                "normalized_count": 16
+            },
+            {
+                "title": "sweet",
+                "count": 6,
+                "normalized_count": 100
+            },
+            {
+                "title": "sugar",
+                "count": 1,
+                "normalized_count": 16
+            },
+            {
+                "title": "chocolate",
+                "count": 1,
+                "normalized_count": 16
+            },
+            {
+                "title": "balanced",
+                "count": 1,
+                "normalized_count": 16
+            }
+        ],
+        "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463682875/nxntecnmngjod4ppbnta.jpg",
+        "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463688901/xloqqvyi16uzf78koz9b.jpg"
+    },
+    {
+        "id": 109,
+        "title": "Black Bottle",
+        "img_url": "https://cdn.shopify.com/s/files/1/0660/2879/products/black-bottle-whisky_1024x1024.png",
+        "region": "Other",
+        "price": 20,
+        "rating": 76,
+        "description": "This is an excellent whiskey with notes of fruit and a strong finish. Accesible, but also complex enough for a seasoned drinker.",
+        "reviews": [],
+        "comparables": [
+            {
+                "id": 420,
+                "title": "Old Pulteney 1990",
+                "img_url": "http://www.nippysweetiewhiskies.com.au/image/cache/catalog/Highland/Old%20Pulteney/png-320x420.png",
+                "rating": 89,
+                "price": 128,
+                "region": "Highland",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683084/zgsuxxkq3boybzfna1eq.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689148/kquykq7uqaofmydo1qdy.jpg"
+            },
+            {
+                "id": 334,
+                "title": "Johnnie Walker Platinum Label",
+                "img_url": "https://www.johnniewalker.com/media/1564/01-johnnie-walker-platinum-18-year-old.png",
+                "rating": 77,
+                "price": 79,
+                "region": "Other",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683023/bcra3eap5o2rwuuuvwhj.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689073/ow3wvxflpj2ghx3jo2jf.jpg"
+            },
+            {
+                "id": 457,
+                "title": "Springbank 10 100 Proof",
+                "img_url": "http://www.leaandsandeman.co.uk/photos/SPRINGBANK-10-Year-Old-100-Proof-Campbeltown.240x700.3575.png",
+                "rating": 92,
+                "price": 68,
+                "region": "Campbeltown",
+                "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463683109/kte8telvtiv9k5w9980v.jpg",
+                "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463689182/lf66zwi6tsuhczlrsifl.jpg"
+            }
+        ],
+        "comparable": [
+            164,
+            376,
+            403,
+            442
+        ],
+        "tags": [
+            {
+                "title": "brown",
+                "count": 2,
+                "normalized_count": 10
+            },
+            {
+                "title": "amber",
+                "count": 2,
+                "normalized_count": 10
+            },
+            {
+                "title": "spicy",
+                "count": 2,
+                "normalized_count": 10
+            },
+            {
+                "title": "sour",
+                "count": 4,
+                "normalized_count": 20
+            },
+            {
+                "title": "smokey",
+                "count": 4,
+                "normalized_count": 20
+            },
+            {
+                "title": "rich",
+                "count": 2,
+                "normalized_count": 10
+            },
+            {
+                "title": "oak",
+                "count": 14,
+                "normalized_count": 70
+            },
+            {
+                "title": "nutty",
+                "count": 1,
+                "normalized_count": 5
+            },
+            {
+                "title": "herbal",
+                "count": 2,
+                "normalized_count": 10
+            },
+            {
+                "title": "bitter",
+                "count": 13,
+                "normalized_count": 65
+            },
+            {
+                "title": "sherry",
+                "count": 4,
+                "normalized_count": 20
+            },
+            {
+                "title": "wood",
+                "count": 6,
+                "normalized_count": 30
+            },
+            {
+                "title": "sugar",
+                "count": 3,
+                "normalized_count": 15
+            },
+            {
+                "title": "peppery",
+                "count": 2,
+                "normalized_count": 10
+            },
+            {
+                "title": "peaty",
+                "count": 2,
+                "normalized_count": 10
+            },
+            {
+                "title": "licorice",
+                "count": 1,
+                "normalized_count": 5
+            },
+            {
+                "title": "floral",
+                "count": 3,
+                "normalized_count": 15
+            },
+            {
+                "title": "coffee",
+                "count": 1,
+                "normalized_count": 5
+            },
+            {
+                "title": "toffee",
+                "count": 3,
+                "normalized_count": 15
+            },
+            {
+                "title": "honey",
+                "count": 10,
+                "normalized_count": 50
+            },
+            {
+                "title": "corn",
+                "count": 3,
+                "normalized_count": 15
+            },
+            {
+                "title": "cocoa",
+                "count": 2,
+                "normalized_count": 10
+            },
+            {
+                "title": "candy",
+                "count": 5,
+                "normalized_count": 25
+            },
+            {
+                "title": "smooth",
+                "count": 6,
+                "normalized_count": 30
+            },
+            {
+                "title": "old",
+                "count": 32,
+                "normalized_count": 160
+            },
+            {
+                "title": "lingering",
+                "count": 2,
+                "normalized_count": 10
+            },
+            {
+                "title": "light",
+                "count": 31,
+                "normalized_count": 155
+            },
+            {
+                "title": "heavy",
+                "count": 4,
+                "normalized_count": 20
+            },
+            {
+                "title": "dry",
+                "count": 5,
+                "normalized_count": 25
+            },
+            {
+                "title": "balanced",
+                "count": 1,
+                "normalized_count": 5
+            },
+            {
+                "title": "raisins",
+                "count": 5,
+                "normalized_count": 25
+            },
+            {
+                "title": "pear",
+                "count": 2,
+                "normalized_count": 10
+            },
+            {
+                "title": "lemon",
+                "count": 6,
+                "normalized_count": 30
+            },
+            {
+                "title": "fruity",
+                "count": 5,
+                "normalized_count": 25
+            },
+            {
+                "title": "citrus",
+                "count": 3,
+                "normalized_count": 15
+            },
+            {
+                "title": "caramel",
+                "count": 13,
+                "normalized_count": 65
+            },
+            {
+                "title": "sweet",
+                "count": 20,
+                "normalized_count": 100
+            },
+            {
+                "title": "salty",
+                "count": 3,
+                "normalized_count": 15
+            },
+            {
+                "title": "brine",
+                "count": 2,
+                "normalized_count": 10
+            },
+            {
+                "title": "vanilla",
+                "count": 9,
+                "normalized_count": 45
+            },
+            {
+                "title": "malty",
+                "count": 17,
+                "normalized_count": 85
+            },
+            {
+                "title": "tea",
+                "count": 1,
+                "normalized_count": 5
+            },
+            {
+                "title": "chocolate",
+                "count": 1,
+                "normalized_count": 5
+            },
+            {
+                "title": "mild",
+                "count": 11,
+                "normalized_count": 55
+            },
+            {
+                "title": "complex",
+                "count": 1,
+                "normalized_count": 5
+            },
+            {
+                "title": "orange",
+                "count": 4,
+                "normalized_count": 20
+            },
+            {
+                "title": "apple",
+                "count": 8,
+                "normalized_count": 40
+            }
+        ],
+        "list_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463682876/odu5mmq5jqyon4tphpr3.jpg",
+        "detail_img_url": "https://res.cloudinary.com/dt4sawqjx/image/upload/v1463688902/whppvajcie2srjgzronf.jpg"
     }
 ]
 }

--- a/src/components/ApplicationView.js
+++ b/src/components/ApplicationView.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Route } from "react-router-dom";
 import { WhiskeyProvider } from "./whiskey/WhiskeyProvider";
 import { WhiskeyList } from "./whiskey/WhiskeyList";
+import { WhiskeySearch } from "./whiskey/WhiskeySearch";
 
 export const ApplicationViews = (props) => {
   return (
@@ -10,7 +11,13 @@ export const ApplicationViews = (props) => {
         <Route
           exact
           path="/search"
-          render={(props) => <WhiskeyList {...props} />}
+          render={(props) => (
+            <>
+                <WhiskeySearch />
+                <WhiskeyList {...props} />
+            </>
+          )}
+
         />
       </WhiskeyProvider>
     </>

--- a/src/components/whiskey/Whiskey.css
+++ b/src/components/whiskey/Whiskey.css
@@ -10,3 +10,9 @@
       padding: 1em;
       border: 1px solid goldenrod;
   }
+
+  .whiskey__image {
+      width: 100px;
+      height: 200px;
+      object-fit: scale-down;
+  }

--- a/src/components/whiskey/Whiskey.js
+++ b/src/components/whiskey/Whiskey.js
@@ -3,7 +3,8 @@ import "./Whiskey.css"
 
 export const Whiskey = ({ whiskey }) => (
     <section className="whiskey">
-        <h3 className="whiskey__name">WHISKEY: {whiskey.title}</h3>
-        <div className="whiskey__image">{whiskey.img_url}</div>
+        <h3 className="whiskey__name">WHISKEY: {whiskey.comparables.title}</h3>
+        {console.table(whiskey.comparables)}
+        {/* <div className="whiskey__image">{whiskey.img_url}</div> */}
     </section>
 )

--- a/src/components/whiskey/Whiskey.js
+++ b/src/components/whiskey/Whiskey.js
@@ -3,8 +3,18 @@ import "./Whiskey.css"
 
 export const Whiskey = ({ whiskey }) => (
     <section className="whiskey">
-        <h3 className="whiskey__name">WHISKEY: {whiskey.comparables.title}</h3>
-        {console.table(whiskey.comparables)}
-        {/* <div className="whiskey__image">{whiskey.img_url}</div> */}
+        <h3 className="whiskey__name">WHISKEY: {whiskey.title}</h3>
+        {console.log("whiskey", whiskey)}
+        <img className="whiskey__image" src={whiskey.list_img_url} />
+        {
+                    whiskey.comparables.map(comparable => {
+                    return (
+                    <>
+                        <h3 className="whiskey__name">COMPARABLES: {comparable.title}</h3>
+                        <img className="whiskey__image" src={comparable.list_img_url} />
+                    </>
+                    )
+                    })
+                }
     </section>
 )

--- a/src/components/whiskey/WhiskeyList.js
+++ b/src/components/whiskey/WhiskeyList.js
@@ -1,22 +1,43 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext, useEffect, useState } from "react";
 // import { Link } from "react-router-dom";
 import { WhiskeyContext } from "./WhiskeyProvider";
 import { Whiskey } from "./Whiskey";
 import "./Whiskey.css"
 
 export const WhiskeyList = (props) => {
-    const { whiskeys, getWhiskeys } = useContext(WhiskeyContext)
+    const { whiskeys, getWhiskeys, searchTerms } = useContext(WhiskeyContext)
+    const [filteredWhiskeys, setFilteredWhiskeys] = useState([])
 
     useEffect(() => {
         getWhiskeys()
     }, [])
 
+    useEffect(() => {
+        if (searchTerms !== "") {
+
+            whiskeys.map(whiskey => {
+
+            })
+
+            const subset = whiskeys.filter(whiskey => whiskey.title.toLowerCase().includes(searchTerms.toLowerCase())) 
+            setFilteredWhiskeys(subset)
+        } else {
+            setFilteredWhiskeys([])
+        }
+    }, [searchTerms, whiskeys])
+
 
   return (
         <div className="whiskeys">
-            {
+            <>
                 <h1>WHISKEYS</h1>
-            }
+
+                {
+                    filteredWhiskeys.map(whiskey => {
+                        return <Whiskey key={whiskey.id} whiskey={whiskey} />
+                    })
+                }
+            </>
         </div>
     )
 

--- a/src/components/whiskey/WhiskeyList.js
+++ b/src/components/whiskey/WhiskeyList.js
@@ -15,11 +15,7 @@ export const WhiskeyList = (props) => {
     useEffect(() => {
         if (searchTerms !== "") {
 
-            whiskeys.map(whiskey => {
-
-            })
-
-            const subset = whiskeys.filter(whiskey => whiskey.title.toLowerCase().includes(searchTerms.toLowerCase())) 
+            const subset = whiskeys.filter(whiskey => whiskey.title.toLowerCase().startsWith(searchTerms.toLowerCase())) 
             setFilteredWhiskeys(subset)
         } else {
             setFilteredWhiskeys([])

--- a/src/components/whiskey/WhiskeyList.js
+++ b/src/components/whiskey/WhiskeyList.js
@@ -12,14 +12,26 @@ export const WhiskeyList = (props) => {
     }, [])
 
 
-    return (
+  return (
         <div className="whiskeys">
             {
-               whiskeys.map(whiskey => <Whiskey key={whiskey.id} whiskey={whiskey} />) 
+                <h1>WHISKEYS</h1>
             }
         </div>
     )
 
+
+    //RETURNS LIST OF WHISKEYS USING WHISKEY FUNCTION FROM WHISKEY.JS
+    // return (
+    //     <div className="whiskeys">
+    //         {
+    //            whiskeys.map(whiskey => <Whiskey key={whiskey.id} whiskey={whiskey} />) 
+    //         }
+    //     </div>
+    // )
+
+
+    //RETURNS LIST OF WHISKEYS FROM THIS MODULE
     // return (
     //     <div className="whiskeys">
     //         <h1>WHISKEYS</h1>

--- a/src/components/whiskey/WhiskeyProvider.js
+++ b/src/components/whiskey/WhiskeyProvider.js
@@ -4,6 +4,7 @@ export const WhiskeyContext = React.createContext();
 
 export const WhiskeyProvider = (props) => {
   const [whiskeys, setWhiskeys] = useState([]);
+  const [searchTerms, setSearchTerms] = useState("")
 
   const getWhiskeys = () => {
     return fetch("http://localhost:8089/whiskeys")
@@ -20,12 +21,16 @@ export const WhiskeyProvider = (props) => {
     }).then(getWhiskeys);
   };
 
+
+
   return (
     <WhiskeyContext.Provider
       value={{
         whiskeys,
         addWhiskey,
         getWhiskeys,
+        searchTerms,
+        setSearchTerms
       }}
     >
       {props.children}

--- a/src/components/whiskey/WhiskeySearch.js
+++ b/src/components/whiskey/WhiskeySearch.js
@@ -1,3 +1,19 @@
-import React from "react"
+import React, { useContext } from "react"
 import "./Whiskey.css"
 import { WhiskeyContext } from "./WhiskeyProvider"
+
+export const WhiskeySearch = (props) => {
+    const { setSearchTerms } = useContext(WhiskeyContext)
+
+    return (
+        <>
+            SEARCH:
+            <input type="text"
+            className="input--wide"
+            onKeyUp={
+                (keyEvent) => setSearchTerms(keyEvent.target.value)
+            }
+            placeholder="ENTER A WHISKEY YOU LIKE" />
+        </>
+    )
+}

--- a/src/components/whiskey/WhiskeySearch.js
+++ b/src/components/whiskey/WhiskeySearch.js
@@ -1,0 +1,3 @@
+import React from "react"
+import "./Whiskey.css"
+import { WhiskeyContext } from "./WhiskeyProvider"


### PR DESCRIPTION
# Description
Added search functionality- search now returns comparables after searching a whiskey name, and returns thumbnail images for both the searched whiskey and the comparables , all of which is rendered to the dom.

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions
Please describe the tests required to verify your changes. Provide instructions so PR Tester can check functionality. Please also list any relevant details for your tests
1. `git fetch --all`
2. `git checkout ps-whiskey-search`
3. `serve`
